### PR TITLE
Removed default class passed to flash

### DIFF
--- a/src/Action/BaseAction.php
+++ b/src/Action/BaseAction.php
@@ -146,7 +146,6 @@ abstract class BaseAction extends Object
 
         $config = Hash::merge([
             'element' => 'default',
-            'params' => ['class' => 'message'],
             'key' => 'flash',
             'type' => $this->config('action') . '.' . $type,
             'name' => $this->resourceName()
@@ -170,8 +169,7 @@ abstract class BaseAction extends Object
             $replacements + ['name' => $config['name']],
             ['before' => '{', 'after' => '}']
         );
-
-        $config['params']['class'] .= ' ' . $type;
+        
         return $config;
     }
 


### PR DESCRIPTION
Removed adding `$type` as class.

This because the `class` could also be an array. And, in some cases we don't want to add `$type` to it the array, can't we do this better manually in the config?
